### PR TITLE
Update link to reference page

### DIFF
--- a/views/index.dt
+++ b/views/index.dt
@@ -179,10 +179,7 @@ block body
 			|)
 			
 		li
-			a(href="http://sdl.ikayzo.org/display/SDL/Language+Guide") Reference
-			| (
-			a(href="http://semitwist.com/sdl-mirror/Language+Guide.html")> mirror
-			|)
+			a(href="https://github.com/Abscissa/SDLang-D/wiki/Language-Guide") Reference
 		li
 			a(href="https://github.com/s-ludwig/sdlang-org/issues") Website issue tracker/Contact
 


### PR DESCRIPTION
Embarrasingly, I only just now noticed that some months ago, somebody was helpful enough to duplicate the old official site's langauge reference (and FAQ) as a Wiki page on SDLang-D's github site.

I went ahead and updated that Wiki page a little (about to do the same to the FAQ), and so I think it may be a better place to direct people towards for an SDLang language reference than the old site+mirror.
